### PR TITLE
feat: add trace regions, raw tx support, witgenMs, per-metric thresholds, and programmatic comparison API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist/
 action/dist/
+examples/output/

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Use the CLI to execute benchmark files written in TypeScript. For CI integration
   - [Options](#options)
   - [Examples](#examples)
 - [Writing Benchmarks](#writing-benchmarks)
+  - [Trace Regions](#trace-regions)
+  - [Raw Transaction Support](#raw-transaction-support)
 - [Benchmark Output](#benchmark-output)
 - [Reusable Workflows](#reusable-workflows)
   - [PR Benchmark (`pr-benchmark.yml`)](#pr-benchmark-pr-benchmarkyml)
@@ -213,6 +215,85 @@ If you provide a `NamedBenchmarkedInteraction` object, its `name` field will be 
 If you provide a plain `ContractFunctionInteractionCallIntent`, the tool will attempt to derive a name from the interaction (e.g., the method name).
 If you return a `feePaymentMethod` in the `BenchmarkContext`, it is automatically passed to every transaction the profiler sends — no changes to `getMethods` are needed.
 
+### Trace Regions
+
+By default, benchmarks report gate counts for the entire transaction trace, including kernel circuit overhead. For contracts like FPCs where you want to isolate specific portions of the trace, implement the optional `getRegions()` method:
+
+```ts
+import { Benchmark } from '@defi-wonderland/aztec-benchmark';
+
+export default class FPCBenchmark extends Benchmark {
+  getRegions() {
+    return [
+      {
+        name: 'fpc-only',
+        startMatch: ['FPC:', 'FPCMultiAsset:'],  // start at first FPC step
+        endMatch: 'Noop:',                        // stop before the Noop delimiter
+      },
+    ];
+  }
+
+  // ... setup(), getMethods(), teardown()
+}
+```
+
+**Region options:**
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `name` | `string` | Display name for this region in reports |
+| `startMatch` | `string \| string[]` | Contract name prefix(es) marking the first step |
+| `endMatch` | `string \| string[]` | Contract name prefix(es) marking the end boundary (exclusive). Omit to include until end of trace |
+| `excludeKernels` | `boolean` | If `true`, filter out `private_kernel_*` and `hiding_kernel` circuits from the region |
+
+The profiler also ships a **built-in kernel isolation preset** that auto-splits the trace into "app" (non-kernel) and "kernel" (overhead) regions:
+
+```ts
+import { Benchmark, kernelIsolation } from '@defi-wonderland/aztec-benchmark';
+
+export default class MyBenchmark extends Benchmark {
+  getRegions() {
+    return kernelIsolation();
+  }
+  // ...
+}
+```
+
+When regions are configured, the JSON report includes:
+- `regions` on each `ProfileResult` — per-region gate count breakdowns
+- `regionSummaries` on the report — region name -> function name -> total gates
+- PR comparison comments show a collapsible **region breakdown** section
+
+### Raw Transaction Support
+
+Some contracts (e.g., cold-start FPCs) must be the transaction root (`msg_sender = None`), bypassing the account entrypoint. For these, return a `RawBenchmarkedInteraction` from `getMethods()`:
+
+```ts
+import { Benchmark, type RawBenchmarkedInteraction } from '@defi-wonderland/aztec-benchmark';
+
+export default class ColdStartBenchmark extends Benchmark {
+  async setup() {
+    // ... build TxExecutionRequest, set up PXE, etc.
+    return { wallet, _coldStartAction: myAction };
+  }
+
+  getMethods(context) {
+    return [{
+      action: context._coldStartAction,  // implements simulate(), profile(), send()
+      caller: context.userAddress,
+      name: 'cold_start_entrypoint',
+    }];
+  }
+}
+```
+
+Your action object must implement:
+- `simulate(opts?)` — should return `{ estimatedGas: { gasLimits, teardownGasLimits } }`
+- `profile(opts?)` — should return a `TxProfileResult`-compatible object with `executionSteps` and `stats`
+- `send(opts?)` — submit the transaction on-chain
+
+The profiler calls these directly **without injecting fee options or origin** — your action manages all transaction construction internally.
+
 ### Wonderland's Usage Example
 
 You can find how we use this tool for benchmarking our Aztec contracts in [`aztec-standards`](https://github.com/defi-wonderland/aztec-standards/tree/dev/benchmarks).
@@ -221,8 +302,36 @@ You can find how we use this tool for benchmarking our Aztec contracts in [`azte
 
 ## Benchmark Output
 
-Your `BenchmarkBase` implementation is responsible for measuring and outputting performance data (e.g., as JSON). The comparison action uses this output.
-Each entry in the output will be identified by the custom `name` you provided (if any) or the auto-derived name.
+The profiler generates a JSON report for each benchmarked contract. Each entry includes:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `totalGateCount` | `number` | Total gates across all circuits |
+| `gateCounts[]` | `GateCount[]` | Per-circuit breakdown with `circuitName`, `gateCount`, and `witgenMs` (witness generation time) |
+| `gas` | `GasLimits` | DA and L2 gas estimates |
+| `provingTime` | `number` | Proving time in ms (hardware-dependent) |
+| `regions` | `Record<string, RegionResult>` | Per-region gate counts (if `getRegions()` is defined) |
+
+**Metric stability:** Gate counts and gas are **deterministic** — identical across runs on any hardware. Witness generation time (`witgenMs`) and proving time are **hardware-dependent** and should not be used for tight regression thresholds in CI. Reports include a `metricStability` field annotating each metric.
+
+### Programmatic Comparison
+
+You can compare two reports programmatically without the CLI:
+
+```ts
+import { compareReports } from '@defi-wonderland/aztec-benchmark';
+
+const result = compareReports(baseReport, prReport, {
+  gates: 1.0,        // 1% threshold for gate counts
+  daGas: 2.5,        // 2.5% for DA gas
+  l2Gas: 2.5,        // 2.5% for L2 gas
+  provingTime: null,  // info-only (never triggers regression)
+});
+
+if (result.hasRegression) {
+  console.log('Regressions detected:', result.entries.filter(e => e.status === 'regression'));
+}
+```
 
 ---
 
@@ -328,7 +437,8 @@ This repository also includes a GitHub Action (defined in `action/action.yml`) t
 
 ### Inputs
 
-- `threshold`: Regression threshold percentage (default: `2.5`).
+- `threshold`: Scalar regression threshold percentage applied to gates, DA gas, and L2 gas (default: `2.5`).
+- `thresholds`: Per-metric thresholds as JSON string. Overrides `threshold` when set. Example: `'{"gates": 1.0, "daGas": 2.5, "l2Gas": 2.5, "provingTime": null}'`. Use `null` for info-only metrics (shown but never trigger regression).
 - `output_markdown_path`: Path to save the generated Markdown comparison report (default: `benchmark-comparison.md`).
 
 ### Outputs

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,250 @@
+# aztec-benchmark Roadmap
+
+Feature roadmap for `aztec-benchmark` — a universal benchmarking tool for Aztec smart contracts.
+
+Inspired by: Foundry's gas profiling, Hyperledger Caliper, BlockBench, zk-Bench, and Noir's native profiler.
+
+---
+
+## Implementation Status
+
+### Phase 1 — Core Features (DONE)
+
+Core profiling features for trace analysis, timing, and non-standard transaction flows.
+
+| ID | Feature | Status | Files |
+|----|---------|--------|-------|
+| 1.1 | Declarative trace regions | Done | `cli/traceRegions.ts` |
+| 1.3 | Kernel isolation preset | Done | `cli/traceRegions.ts` — `kernelIsolation()` |
+| 1.4 | Noop boundary convention | Done | `cli/traceRegions.ts` — `endMatch` support |
+| 2.1 | Witness generation timing (witgenMs) | Done | `cli/profiler.ts` — `step.timings.witgen` |
+| 3.1 | Raw TxExecutionRequest support | Done | `cli/rawInteraction.ts`, `cli/profiler.ts` — `#profileOneRaw` |
+| 7.1 | Per-region regression detection | Done | `action/comparison.cjs` — `generateRegionComparisonSection()` |
+
+### Phase 2 — CI & Programmatic API (DONE)
+
+Features that make CI actionable for region-based projects and expose comparison logic for programmatic use.
+
+| ID | Feature | Status | Files |
+|----|---------|--------|-------|
+| 7.2 | Configurable thresholds per metric | Done | `action/comparison.cjs` — `normalizeThresholds()`, `action/action.yml` — `thresholds` input |
+| 2.5 | Timing stability annotations | Done | `cli/profiler.ts` — `metricStability` in report, `cli/types.ts` |
+| 11.6 | Programmatic comparison API | Done | `cli/comparison.ts` — `compareReports()` |
+
+---
+
+## Pending Features
+
+### Phase 3 — Deeper Metrics & Reporting
+
+| ID | Feature | Description | Effort |
+|----|---------|-------------|--------|
+| 5.4 | Note/nullifier/log accounting | Count notes created, nullifiers emitted, encrypted/unencrypted logs per function. Drives DA gas understanding. | Medium |
+| 10.1 | Version pinning in reports | Record Noir, Barretenberg, SDK, Node.js versions in every report. Warn when comparing across versions. | Low |
+| 9.1 | Gate count diff attribution | When comparing base vs PR, attribute gate count delta to specific functions/operations. | Medium |
+| 7.6 | Collapsible PR comments | Use `<details>` tags more aggressively for complex benchmarks — summary at top, per-contract/per-region details below. | Low |
+
+### Phase 4 — Advanced Profiling & Parameterization
+
+| ID | Feature | Description | Effort |
+|----|---------|-------------|--------|
+| 1.2 | Regex/glob matching for regions | Support regex patterns for region boundaries (e.g., `/Token:(transfer\|mint)/`). Currently only prefix matching. | Low |
+| 4.1 | Automated flamegraph generation | After profiling, invoke `noir-profiler gates` and attach SVG flamegraphs to benchmark report. | Medium |
+| 4.4 | Differential flamegraphs | Generate diff flamegraphs (Brendan Gregg style) highlighting operations that got more/less expensive between base and PR. | Medium |
+| 8.1 | Parameterized benchmarks | Allow `getMethods()` to return parameterized interactions (e.g., transfer with 1, 2, 4, 8 notes) and plot gate count growth. | Medium |
+| 3.3 | Multi-phase transaction support | Benchmark transactions with distinct setup/app/teardown phases, with per-phase metrics matching Aztec's execution model. | Medium |
+
+---
+
+## Full Feature Catalog
+
+Below is the complete original proposal set. Features marked **DONE** are implemented. The rest are organized by category for reference.
+
+### 1. Trace Slicing & Region Extraction
+
+- **1.1 — Declarative trace regions.** DONE. Benchmark authors define named regions via `getRegions()` with `startMatch`/`endMatch` patterns. The profiler slices `executionSteps` and produces per-region summaries in the JSON report.
+
+- **1.2 — Regex and glob matching.** PENDING. Currently only prefix matching (`startsWith`). Support regex patterns for region boundaries (e.g., `/Token:(transfer|mint)/`) and glob-style contract name matching (e.g., `FPC*`).
+
+- **1.3 — Kernel isolation.** DONE. Built-in `kernelIsolation()` preset auto-separates kernel circuits (`private_kernel_*`, `hiding_kernel`) from application logic. Produces "app gates" vs "kernel overhead" breakdown.
+
+- **1.4 — Noop boundary convention.** DONE. The `endMatch` parameter supports the Noop-contract-as-delimiter pattern. If the benchmark declares a delimiter contract, the runner automatically extracts the region between the entrypoint and the delimiter.
+
+- **1.5 — Nested region support.** PENDING. Allow regions to nest (e.g., "full FPC teardown" containing sub-regions "token transfer" and "authwit verification"), producing a hierarchical gate count breakdown.
+
+### 2. Witness Generation & Execution Timing
+
+- **2.1 — Surface `witgenMs` per circuit step.** DONE. Each `GateCount` entry includes `witgenMs` from `PrivateExecutionStep.timings.witgen`.
+
+- **2.2 — Compilation time tracking.** PENDING. Measure and report `aztec compile` time for the contract under test. Useful for tracking Noir compiler regressions.
+
+- **2.3 — PXE simulation time.** PENDING. Capture and report the time taken by PXE to simulate the transaction (before proving), which reflects unconstrained execution cost.
+
+- **2.4 — Proving time breakdown.** PENDING. Instead of a single `provingTime` number, break it down per-circuit where possible (per-step proving time from the SDK if available).
+
+- **2.5 — Timing stability annotations.** DONE. Report includes `metricStability` field marking each metric as `"deterministic"` (gate count, gas) or `"hardware-dependent"` (witgenMs, proving time). CI tooling uses this to auto-select default thresholds.
+
+### 3. Non-Standard Transaction Flows
+
+- **3.1 — Raw `TxExecutionRequest` support.** DONE. `getMethods()` can return `RawBenchmarkedInteraction` objects with a `ProfileableAction` duck-typed interface. The profiler calls `simulate()`, `profile()`, `send()` without injecting fee options — the action manages everything.
+
+- **3.2 — Custom `msg_sender` configuration.** PENDING. Allow benchmarks to specify that the contract is the tx root without manually constructing execution requests.
+
+- **3.3 — Multi-phase transaction support.** PENDING. Support benchmarking transactions with distinct setup, app, and teardown phases, with per-phase metrics.
+
+- **3.4 — Batched transaction profiling.** PENDING. Profile multiple transactions in sequence to measure how state changes affect gate counts.
+
+### 4. Flamegraph Integration
+
+- **4.1 — Automated flamegraph generation.** PENDING. After profiling, invoke `noir-profiler gates` for each contract function and attach SVG flamegraphs to the benchmark report.
+
+- **4.2 — ACIR opcode flamegraphs.** PENDING. Generate ACIR-level flamegraphs via `noir-profiler opcodes`.
+
+- **4.3 — Brillig execution flamegraphs.** PENDING. For unconstrained functions, generate Brillig opcode flamegraphs.
+
+- **4.4 — Differential flamegraphs.** PENDING. Generate diff flamegraphs highlighting which operations got more/less expensive between base and PR.
+
+- **4.5 — Flamegraph search integration.** PENDING. Embed interactive SVGs with search support.
+
+### 5. Multi-Level Metric Collection
+
+- **5.1 — ACIR opcode counts.** PENDING. Report ACIR opcodes per function from `nargo info`. Useful because ACIR opcode count and backend gate count can diverge.
+
+- **5.2 — Backend gate type breakdown.** PENDING. Report gate types (arithmetic, range, EC, lookup) per circuit if Barretenberg exposes it.
+
+- **5.3 — Memory operation tracking.** PENDING. Count RAM vs ROM operations. Dynamic array access (RAM) is ~60% more expensive than static (ROM).
+
+- **5.4 — Note/nullifier/log accounting.** PENDING. Count notes created, nullifiers emitted, and logs per function. Directly drives DA gas costs.
+
+- **5.5 — Call graph depth and breadth.** PENDING. Report call graph structure: internal calls, nesting depth, kernel circuits triggered.
+
+- **5.6 — Public function metrics.** PENDING. For public functions (AVM execution), report AVM opcode counts, L2 gas consumed, and simulation time separately from private metrics.
+
+### 6. Gas Economics & Cost Estimation
+
+- **6.1 — Fee estimation in ETH/USD.** PENDING. Given gas price assumptions, estimate L1 settlement cost and L2 execution cost.
+
+- **6.2 — DA gas breakdown.** PENDING. Break down DA gas into proof size, log size, and note encryption overhead.
+
+- **6.3 — Gas limit budget tracking.** PENDING. Compare measured gas against protocol-defined limits.
+
+- **6.4 — Gas per note/transfer.** PENDING. Compute derived metrics for apples-to-apples comparison.
+
+- **6.5 — Teardown gas isolation.** PENDING. Separately report teardown phase gas vs app phase gas.
+
+### 7. CI & Reporting Enhancements
+
+- **7.1 — Per-region regression detection.** DONE. The comparison module generates per-region gate count comparison tables in collapsible `<details>` sections on PR comments.
+
+- **7.2 — Configurable thresholds per metric.** DONE. Action accepts `thresholds` JSON input (e.g., `{"gates": 1.0, "daGas": 2.5, "provingTime": null}`). `null` means info-only. Backward compatible with scalar `threshold` input.
+
+- **7.3 — HTML report generation.** PENDING. Interactive HTML report with tables, flamegraphs, and charts.
+
+- **7.4 — Historical trend tracking.** PENDING. Store results over time and generate trend charts.
+
+- **7.5 — Multi-contract comparison matrix.** PENDING. Side-by-side comparison of multiple contracts.
+
+- **7.6 — Structured PR comment with collapsible sections.** PARTIALLY DONE. Circuit details and region breakdowns use `<details>` tags. Could be more aggressive.
+
+- **7.7 — Badge/shield generation.** PENDING.
+
+- **7.8 — Slack/Discord notifications.** PENDING.
+
+### 8. Workload Patterns & Parameterization
+
+- **8.1 — Parameterized benchmarks.** PENDING. Allow `getMethods()` to return parameterized interactions and plot gate count growth.
+
+- **8.2 — Standard workload profiles.** PENDING. Built-in templates for common patterns (ERC20 transfer, DEX swap, etc.).
+
+- **8.3 — Warmup/cooldown separation.** PENDING.
+
+- **8.4 — Concurrency simulation.** PENDING.
+
+- **8.5 — State-dependent benchmarking.** PENDING.
+
+### 9. Developer Experience & Debugging
+
+- **9.1 — Gate count diff attribution.** PENDING. Attribute gate count delta to specific functions when comparing.
+
+- **9.2 — Optimization hints.** PENDING.
+
+- **9.3 — `nargo info` integration.** PENDING.
+
+- **9.4 — Circuit size warnings.** PENDING.
+
+- **9.5 — Interactive profiling mode.** PENDING.
+
+- **9.6 — Verbose trace logging.** PENDING.
+
+### 10. Cross-Version & Cross-Backend Benchmarking
+
+- **10.1 — Version pinning in reports.** PENDING. Record exact versions of Noir, BB, SDK in reports.
+
+- **10.2 — Multi-version benchmarking.** PENDING.
+
+- **10.3 — Backend-agnostic reporting.** PENDING.
+
+- **10.4 — Noir compiler optimization flags.** PENDING.
+
+### 11. Composability & Ecosystem Integration
+
+- **11.1 — TXE support.** PENDING.
+
+- **11.2 — Plugin architecture.** PENDING.
+
+- **11.3 — Scaffold command.** PENDING.
+
+- **11.4 — JSON Schema for reports.** PENDING.
+
+- **11.5 — Export to common formats.** PENDING.
+
+- **11.6 — Programmatic API.** DONE. `compareReports()` function takes two `ProfileReport` objects and `MetricThresholds`, returns structured `ComparisonResult` with per-entry status and per-region diffs. Exported from the package.
+
+### 12. Resource Monitoring
+
+- **12.1 — Peak memory tracking.** PENDING.
+- **12.2 — CPU utilization profiling.** PENDING.
+- **12.3 — Proving throughput metric.** PENDING.
+- **12.4 — Hardware class recommendations.** PENDING.
+
+### 13. Security-Adjacent Profiling
+
+- **13.1 — Unconstrained function accounting.** PENDING.
+- **13.2 — Constraint density analysis.** PENDING.
+- **13.3 — Note encryption cost tracking.** PENDING.
+
+### 14. Comparative Benchmarking
+
+- **14.1 — Reference benchmark suite.** PENDING.
+- **14.2 — Cross-project comparison.** PENDING.
+- **14.3 — Public benchmark registry.** PENDING.
+
+---
+
+## Architecture Notes
+
+### Key files added/modified (Phases 1-2)
+
+| File | Purpose |
+|------|---------|
+| `cli/traceRegions.ts` | Region extraction engine: `extractRegion()`, `kernelIsolation()`, `applyRegions()` |
+| `cli/rawInteraction.ts` | `ProfileableAction` interface, `RawBenchmarkedInteraction` type, `isRawInteraction()` guard |
+| `cli/comparison.ts` | Programmatic comparison API: `compareReports()`, `MetricThresholds`, `ComparisonResult` |
+| `cli/types.ts` | Extended with `witgenMs`, `regions`, `regionSummaries`, `metricStability`, `BenchmarkableItem` |
+| `cli/profiler.ts` | Captures `witgenMs`, handles raw interactions via `#profileOneRaw`, applies regions in `saveResults()` |
+| `cli/cli.ts` | Reads `getRegions()` from benchmark, passes to profiler |
+| `action/comparison.cjs` | Per-metric thresholds (`normalizeThresholds`), per-region comparison tables |
+| `action/index.cjs` | Parses `thresholds` JSON input |
+| `action/action.yml` | New `thresholds` input |
+
+### Design principles
+
+1. **New logic in new files** — minimizes merge conflicts with upstream
+2. **Additive-only changes to existing files** — optional fields, new imports, new hook calls
+3. **Backward compatible** — all new features are opt-in; existing benchmarks produce identical output plus new optional fields
+4. **Duck-typing for raw interactions** — `ProfileableAction` interface lets benchmark authors implement custom simulate/profile/send without subclassing
+
+### Validated against
+
+- **FPC-style contracts** — Trace slicing, witgenMs, raw TxExecutionRequest, kernel isolation, per-region comparison
+- **Standard contract patterns** — Private/public functions, cross-contract calls, batch operations, capsule-based data delivery

--- a/action/action.yml
+++ b/action/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: 'If true, includes per-circuit gate count breakdown in an expandable section below each contract table.'
     required: false
     default: 'false'
+  thresholds:
+    description: 'Per-metric regression thresholds as JSON (e.g., {"gates": 1.0, "daGas": 2.5, "l2Gas": 2.5, "provingTime": null}). Overrides scalar threshold when set. null = info-only.'
+    required: false
+    default: ''
 outputs:
   comparison_markdown:
     description: "The generated comparison report in Markdown format."

--- a/action/comparison.cjs
+++ b/action/comparison.cjs
@@ -67,9 +67,28 @@ const formatDiff = (main, pr) => {
 };
 
 /**
- * Determines an emoji status based on benchmark metric changes and a threshold.
+ * Normalizes a threshold input into a per-metric thresholds object.
+ * Accepts either a single number (applied to gates/daGas/l2Gas, provingTime info-only)
+ * or an object with per-metric thresholds. null means info-only (never triggers regression).
+ * @param {number|object} threshold - Scalar percentage or per-metric thresholds object.
+ * @returns {object} Normalized thresholds: { gates, daGas, l2Gas, provingTime }.
+ */
+function normalizeThresholds(threshold) {
+  if (typeof threshold === 'number') {
+    return { gates: threshold, daGas: threshold, l2Gas: threshold, provingTime: null };
+  }
+  return {
+    gates: threshold.gates ?? 2.5,
+    daGas: threshold.daGas ?? 2.5,
+    l2Gas: threshold.l2Gas ?? 2.5,
+    provingTime: threshold.provingTime ?? null,
+  };
+}
+
+/**
+ * Determines an emoji status based on benchmark metric changes and per-metric thresholds.
  * @param {object} metrics - An object containing main and pr values for gates, daGas, and l2Gas.
- * @param {number} threshold - The percentage threshold for significant change.
+ * @param {number|object} threshold - Scalar percentage or per-metric thresholds object.
  * @returns {string} An emoji: '🚮' for removed, '🆕' for new, '🔴' for regression, '🟢' for improvement, '⚪' for no significant change.
  */
 const getStatusEmoji = (metrics, threshold) => {
@@ -81,6 +100,8 @@ const getStatusEmoji = (metrics, threshold) => {
   if (isRemoved) return '🚮';
   if (isNew) return '🆕';
 
+  const t = normalizeThresholds(threshold);
+
   // Avoid division by zero, handle infinite increases
   const gateDiffPct = metrics.gates.main === 0 ? (metrics.gates.pr > 0 ? Infinity : 0) :
                     (metrics.gates.pr - metrics.gates.main) / metrics.gates.main;
@@ -89,14 +110,17 @@ const getStatusEmoji = (metrics, threshold) => {
   const l2GasDiffPct = metrics.l2Gas.main === 0 ? (metrics.l2Gas.pr > 0 ? Infinity : 0) :
                     (metrics.l2Gas.pr - metrics.l2Gas.main) / metrics.l2Gas.main;
 
-  const metricsDiffs = [gateDiffPct, daGasDiffPct, l2GasDiffPct].filter(m => isFinite(m));
-  const hasInfiniteIncrease = [gateDiffPct, daGasDiffPct, l2GasDiffPct].some(m => m === Infinity);
+  // Build checks only for metrics that have a non-null threshold
+  const checks = [];
+  if (t.gates != null) checks.push({ diff: gateDiffPct, threshold: t.gates / 100.0 });
+  if (t.daGas != null) checks.push({ diff: daGasDiffPct, threshold: t.daGas / 100.0 });
+  if (t.l2Gas != null) checks.push({ diff: l2GasDiffPct, threshold: t.l2Gas / 100.0 });
 
-  // Use threshold percentage directly
-  const thresholdDecimal = threshold / 100.0;
+  const finiteChecks = checks.filter(c => isFinite(c.diff));
+  const hasInfiniteIncrease = checks.some(c => c.diff === Infinity);
 
-  const hasRegression = hasInfiniteIncrease || metricsDiffs.some(m => m > thresholdDecimal);
-  const hasImprovement = metricsDiffs.some(m => m < -thresholdDecimal);
+  const hasRegression = hasInfiniteIncrease || finiteChecks.some(c => c.diff > c.threshold);
+  const hasImprovement = finiteChecks.some(c => c.diff < -c.threshold);
 
   if (hasRegression) return '🔴'; // Regression
   if (hasImprovement) return '🟢'; // Improvement
@@ -189,6 +213,78 @@ function generateCircuitBreakdownSection(comparison, sortedNames, contractName) 
 }
 
 /**
+ * Generates a collapsible section showing per-region gate count comparisons.
+ * Each region gets its own table showing Base vs PR vs Diff for total gates.
+ * @param {object} comparison - The comparison object keyed by function name.
+ * @param {string[]} sortedNames - Sorted function names.
+ * @param {number} threshold - Regression threshold percentage.
+ * @param {string} contractName - The contract name for the section header.
+ * @returns {string} HTML string with collapsible region comparisons, or empty string if no region data.
+ */
+function generateRegionComparisonSection(comparison, sortedNames, threshold, contractName) {
+  // Check if any function has region data
+  const hasRegionData = sortedNames.some(name => {
+    const regions = comparison[name]?.regions;
+    return regions && (Object.keys(regions.pr).length > 0 || Object.keys(regions.main).length > 0);
+  });
+  if (!hasRegionData) return '';
+
+  // Collect all region names across all functions
+  const allRegionNames = new Set();
+  for (const funcName of sortedNames) {
+    const regions = comparison[funcName]?.regions;
+    if (regions) {
+      for (const name of Object.keys(regions.main)) allRegionNames.add(name);
+      for (const name of Object.keys(regions.pr)) allRegionNames.add(name);
+    }
+  }
+
+  if (allRegionNames.size === 0) return '';
+
+  const lines = [
+    '<details>',
+    `<summary>📊 ${contractName} region breakdown</summary>`,
+    '',
+  ];
+
+  for (const regionName of [...allRegionNames].sort()) {
+    lines.push(
+      `#### Region: \`${regionName}\``,
+      '',
+      '| 🚦 | Function | Base Gates | PR Gates | Diff |',
+      '|:---:|----------|----------:|--------:|------|',
+    );
+
+    for (const funcName of sortedNames) {
+      const regions = comparison[funcName]?.regions;
+      const mainRegion = regions?.main?.[regionName];
+      const prRegion = regions?.pr?.[regionName];
+
+      const mainGates = mainRegion?.totalGateCount ?? 0;
+      const prGates = prRegion?.totalGateCount ?? 0;
+
+      // Determine status for this region
+      const regionMetrics = {
+        gates: { main: mainGates, pr: prGates },
+        daGas: { main: 0, pr: 0 },
+        l2Gas: { main: 0, pr: 0 },
+      };
+      const emoji = getStatusEmoji(regionMetrics, threshold);
+      const diff = formatDiff(mainGates, prGates);
+
+      lines.push(
+        `| ${emoji} | \`${funcName}\` | ${mainGates.toLocaleString()} | ${prGates.toLocaleString()} | ${diff} |`,
+      );
+    }
+
+    lines.push('');
+  }
+
+  lines.push('</details>');
+  return lines.join('\n');
+}
+
+/**
  * Generates an HTML table comparing benchmark results for a single contract.
  * Handles new contracts where baseJsonPath may be null (no base report exists).
  * @param {object} pair - An object containing contractName, baseJsonPath (or null), and prJsonPath.
@@ -252,6 +348,7 @@ function generateContractComparisonTable(pair, threshold, { circuitDetails = fal
       l2Gas: { main: getL2Gas(mainResult), pr: getL2Gas(prResult) },
       provingTime: { main: getProvingTime(mainResult), pr: getProvingTime(prResult) },
       gateCounts: { main: mainResult?.gateCounts ?? [], pr: prResult?.gateCounts ?? [] },
+      regions: { main: mainResult?.regions ?? {}, pr: prResult?.regions ?? {} },
     };
   }
 
@@ -333,6 +430,12 @@ function generateContractComparisonTable(pair, threshold, { circuitDetails = fal
     if (circuitSection) {
       output.push('', circuitSection);
     }
+  }
+
+  // Add per-region comparison sections if any results have region data
+  const regionSection = generateRegionComparisonSection(comparison, sortedNames, threshold, contractName);
+  if (regionSection) {
+    output.push('', regionSection);
   }
 
   return output.join('\n');

--- a/action/index.cjs
+++ b/action/index.cjs
@@ -17,7 +17,10 @@ const { runComparison } = require('./comparison.cjs');
  */
 async function run() {
   try {
-    const threshold = parseFloat(core.getInput('threshold'));
+    const thresholdsInput = core.getInput('thresholds');
+    const threshold = thresholdsInput
+      ? JSON.parse(thresholdsInput)
+      : parseFloat(core.getInput('threshold'));
     const outputMarkdownPath = core.getInput('output_markdown_path');
     const baseSuffix = core.getInput('base_suffix');
     const currentSuffix = core.getInput('current_suffix');

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4,8 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import toml from '@iarna/toml';
 import { Profiler } from './profiler.js';
-import { BenchmarkBase, BenchmarkContext, type ProfileResult, type NamedBenchmarkedInteraction } from './types.js';
-import type { ContractFunctionInteractionCallIntent } from '@aztec/aztec.js/authorization';
+import { BenchmarkBase, BenchmarkContext, type BenchmarkableItem } from './types.js';
 
 /**
  * Represents the structure of the [benchmark] section in Nargo.toml.
@@ -129,10 +128,14 @@ program
           process.exit(1);
         }
 
-        const profiler = new Profiler(runContext.wallet, { skipProving: options.skipProving, feePaymentMethod: runContext.feePaymentMethod });
+        const regions = typeof benchmarkInstance.getRegions === 'function'
+          ? benchmarkInstance.getRegions()
+          : undefined;
+
+        const profiler = new Profiler(runContext.wallet, { skipProving: options.skipProving, feePaymentMethod: runContext.feePaymentMethod, regions });
 
         console.log(`Getting methods to benchmark for ${contractName}...`);
-        const interactionsToBenchmark: Array<ContractFunctionInteractionCallIntent | NamedBenchmarkedInteraction> = benchmarkInstance.getMethods(runContext);
+        const interactionsToBenchmark: BenchmarkableItem[] = benchmarkInstance.getMethods(runContext);
 
         if (!Array.isArray(interactionsToBenchmark) || interactionsToBenchmark.length === 0) {
           console.warn(`No benchmark methods returned by getMethods for ${contractName}. Saving empty report.`);

--- a/cli/comparison.ts
+++ b/cli/comparison.ts
@@ -1,0 +1,162 @@
+import type { ProfileReport, ProfileResult, RegionResult } from './types.js';
+
+/** Per-metric regression thresholds. Values are percentages (e.g., 2.5 = 2.5%). null = info-only (never triggers regression). */
+export interface MetricThresholds {
+  /** Gate count threshold %. Default: 2.5 */
+  gates?: number | null;
+  /** DA gas threshold %. Default: 2.5 */
+  daGas?: number | null;
+  /** L2 gas threshold %. Default: 2.5 */
+  l2Gas?: number | null;
+  /** Proving time threshold %. Default: null (info-only, hardware-dependent). */
+  provingTime?: number | null;
+}
+
+/** A single metric's base vs PR comparison. */
+export interface MetricDiff {
+  base: number;
+  pr: number;
+  /** Percentage change. Infinity if base was 0 and pr > 0. */
+  diffPct: number;
+}
+
+/** Comparison result for a single benchmarked function. */
+export interface ComparisonEntry {
+  name: string;
+  gates: MetricDiff;
+  daGas: MetricDiff;
+  l2Gas: MetricDiff;
+  provingTime: MetricDiff;
+  /** Per-region gate count comparison (region name → diff). */
+  regions: Record<string, MetricDiff>;
+  status: 'regression' | 'improvement' | 'unchanged' | 'new' | 'removed';
+}
+
+/** Result of comparing two benchmark reports. */
+export interface ComparisonResult {
+  entries: ComparisonEntry[];
+  /** True if any entry has status 'regression'. */
+  hasRegression: boolean;
+}
+
+const DEFAULT_THRESHOLDS: Required<MetricThresholds> = {
+  gates: 2.5,
+  daGas: 2.5,
+  l2Gas: 2.5,
+  provingTime: null,
+};
+
+function pctChange(base: number, pr: number): number {
+  if (base === 0 && pr === 0) return 0;
+  if (base === 0) return Infinity;
+  return ((pr - base) / base) * 100;
+}
+
+function makeDiff(base: number, pr: number): MetricDiff {
+  return { base, pr, diffPct: pctChange(base, pr) };
+}
+
+function getDaGas(r?: ProfileResult): number {
+  return r?.gas?.gasLimits?.daGas ?? 0;
+}
+
+function getL2Gas(r?: ProfileResult): number {
+  return r?.gas?.gasLimits?.l2Gas ?? 0;
+}
+
+function resolveThresholds(t?: MetricThresholds | number): Required<MetricThresholds> {
+  if (t == null) return { ...DEFAULT_THRESHOLDS };
+  if (typeof t === 'number') return { gates: t, daGas: t, l2Gas: t, provingTime: null };
+  return {
+    gates: t.gates !== undefined ? t.gates : DEFAULT_THRESHOLDS.gates,
+    daGas: t.daGas !== undefined ? t.daGas : DEFAULT_THRESHOLDS.daGas,
+    l2Gas: t.l2Gas !== undefined ? t.l2Gas : DEFAULT_THRESHOLDS.l2Gas,
+    provingTime: t.provingTime !== undefined ? t.provingTime : DEFAULT_THRESHOLDS.provingTime,
+  };
+}
+
+function computeStatus(
+  entry: ComparisonEntry,
+  thresholds: Required<MetricThresholds>,
+): ComparisonEntry['status'] {
+  const isAllZeroBase = entry.gates.base === 0 && entry.daGas.base === 0 && entry.l2Gas.base === 0;
+  const isAllZeroPr = entry.gates.pr === 0 && entry.daGas.pr === 0 && entry.l2Gas.pr === 0;
+
+  if (isAllZeroPr && !isAllZeroBase) return 'removed';
+  if (isAllZeroBase && !isAllZeroPr) return 'new';
+
+  const checks: { diffPct: number; threshold: number }[] = [];
+  if (thresholds.gates != null) checks.push({ diffPct: entry.gates.diffPct, threshold: thresholds.gates });
+  if (thresholds.daGas != null) checks.push({ diffPct: entry.daGas.diffPct, threshold: thresholds.daGas });
+  if (thresholds.l2Gas != null) checks.push({ diffPct: entry.l2Gas.diffPct, threshold: thresholds.l2Gas });
+  if (thresholds.provingTime != null) checks.push({ diffPct: entry.provingTime.diffPct, threshold: thresholds.provingTime });
+
+  const hasInfinite = checks.some(c => c.diffPct === Infinity);
+  const hasRegression = hasInfinite || checks.some(c => isFinite(c.diffPct) && c.diffPct > c.threshold);
+  const hasImprovement = checks.some(c => isFinite(c.diffPct) && c.diffPct < -c.threshold);
+
+  if (hasRegression) return 'regression';
+  if (hasImprovement) return 'improvement';
+  return 'unchanged';
+}
+
+/**
+ * Compare two benchmark reports programmatically.
+ *
+ * Returns structured comparison data for each function, including per-region
+ * breakdowns and regression/improvement status based on configurable thresholds.
+ *
+ * @param base - The baseline report (e.g., from main branch).
+ * @param pr - The PR/current report.
+ * @param thresholds - Per-metric thresholds. A number applies to gates/daGas/l2Gas uniformly.
+ */
+export function compareReports(
+  base: ProfileReport,
+  pr: ProfileReport,
+  thresholds?: MetricThresholds | number,
+): ComparisonResult {
+  const resolved = resolveThresholds(thresholds);
+
+  const allNames = new Set([
+    ...base.results.map(r => r.name),
+    ...pr.results.map(r => r.name),
+  ]);
+
+  const entries: ComparisonEntry[] = [];
+
+  for (const name of allNames) {
+    if (!name || name.startsWith('unknown_function') || name.includes('(FAILED)')) continue;
+
+    const baseResult = base.results.find(r => r.name === name);
+    const prResult = pr.results.find(r => r.name === name);
+
+    // Build per-region diffs
+    const regionNames = new Set([
+      ...Object.keys(baseResult?.regions ?? {}),
+      ...Object.keys(prResult?.regions ?? {}),
+    ]);
+    const regions: Record<string, MetricDiff> = {};
+    for (const regionName of regionNames) {
+      const baseGates = baseResult?.regions?.[regionName]?.totalGateCount ?? 0;
+      const prGates = prResult?.regions?.[regionName]?.totalGateCount ?? 0;
+      regions[regionName] = makeDiff(baseGates, prGates);
+    }
+
+    const entry: ComparisonEntry = {
+      name,
+      gates: makeDiff(baseResult?.totalGateCount ?? 0, prResult?.totalGateCount ?? 0),
+      daGas: makeDiff(getDaGas(baseResult), getDaGas(prResult)),
+      l2Gas: makeDiff(getL2Gas(baseResult), getL2Gas(prResult)),
+      provingTime: makeDiff(baseResult?.provingTime ?? 0, prResult?.provingTime ?? 0),
+      regions,
+      status: 'unchanged', // computed below
+    };
+    entry.status = computeStatus(entry, resolved);
+    entries.push(entry);
+  }
+
+  return {
+    entries,
+    hasRegression: entries.some(e => e.status === 'regression'),
+  };
+}

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,6 +1,7 @@
 // Export the base class and types for users
 export { BenchmarkBase as Benchmark, BenchmarkContext } from './types.js'; // Alias BenchmarkBase to Benchmark for user convenience
-export type { ProfileReport, ProfileResult, GateCount, SystemInfo, NamedBenchmarkedInteraction } from './types.js';
+export type { ProfileReport, ProfileResult, GateCount, SystemInfo, NamedBenchmarkedInteraction, BenchmarkableItem } from './types.js';
+export type { TraceRegion, RegionResult, RawBenchmarkedInteraction, ProfileableAction, MetricThresholds, ComparisonEntry, ComparisonResult } from './types.js';
 
 // Export system info utilities
 export { getSystemInfo } from './systemInfo.js';
@@ -11,3 +12,12 @@ export { Profiler } from './profiler.js';
 // Export fee payment helpers
 export { FeeWrappedInteraction, namedMethod } from './feeWrappedInteraction.js';
 export type { FeeGasSettings, FeeOptions } from './feeWrappedInteraction.js';
+
+// Export trace region utilities
+export { extractRegion, extractKernelOverhead, extractAppLogic, applyRegions, kernelIsolation, isKernelCircuit } from './traceRegions.js';
+
+// Export raw interaction utilities
+export { isRawInteraction } from './rawInteraction.js';
+
+// Export programmatic comparison API
+export { compareReports } from './comparison.js';

--- a/cli/profiler.ts
+++ b/cli/profiler.ts
@@ -10,8 +10,11 @@ import {
   type Gas,
   type GasLimits,
   type NamedBenchmarkedInteraction,
+  type BenchmarkableItem,
 } from './types.js';
 import { getSystemInfo } from './systemInfo.js';
+import { applyRegions, type TraceRegion } from './traceRegions.js';
+import { isRawInteraction, type RawBenchmarkedInteraction } from './rawInteraction.js';
 
 /**
  * Sums all numbers in an array.
@@ -35,6 +38,8 @@ interface ProfilerOptions {
   skipProving?: boolean;
   /** Fee payment method to use when sending transactions. */
   feePaymentMethod?: FeePaymentMethod;
+  /** Trace regions to extract per-region gate count breakdowns. */
+  regions?: TraceRegion[];
 }
 
 /**
@@ -43,11 +48,13 @@ interface ProfilerOptions {
 export class Profiler {
   #skipProving: boolean;
   #feePaymentMethod?: FeePaymentMethod;
+  #regions?: TraceRegion[];
 
   /** @param _wallet - Unused, kept for backward compatibility with existing callers. */
   constructor(_wallet?: EmbeddedWallet, options?: ProfilerOptions) {
     this.#skipProving = options?.skipProving ?? false;
     this.#feePaymentMethod = options?.feePaymentMethod;
+    this.#regions = options?.regions;
   }
 
   /**
@@ -56,10 +63,13 @@ export class Profiler {
    * @param fsToProfile - An array of items to profile.
    * @returns A promise that resolves to an array of profile results.
    */
-  async profile(fsToProfile: Array<ContractFunctionInteractionCallIntent | NamedBenchmarkedInteraction>): Promise<ProfileResult[]> {
+  async profile(fsToProfile: BenchmarkableItem[]): Promise<ProfileResult[]> {
     const results: ProfileResult[] = [];
     for (const item of fsToProfile) {
-      if ('interaction' in item && 'name' in item) {
+      if (isRawInteraction(item)) {
+        // Raw interaction — action handles its own simulate/profile/send
+        results.push(await this.#profileOneRaw(item));
+      } else if ('interaction' in item && 'name' in item) {
         // This is a NamedBenchmarkedInteraction object
         results.push(await this.#profileOne(item.interaction, item.name, item.additionalScopes));
       } else {
@@ -114,11 +124,33 @@ export class Profiler {
       {} as Record<string, number>,
     );
 
+    // Apply trace region extraction if regions are configured
+    if (this.#regions?.length) {
+      for (const result of results) {
+        if (result.gateCounts.length) {
+          result.regions = applyRegions(result.gateCounts, this.#regions);
+        }
+      }
+    }
+
+    // Build per-region summaries: region name → function name → total gates
+    const regionSummaries = this.#regions?.length
+      ? this.#buildRegionSummaries(results)
+      : undefined;
+
     const report: ProfileReport = {
       summary,
       results: results,
       gasSummary,
       provingTimeSummary,
+      regionSummaries,
+      metricStability: {
+        totalGateCount: 'deterministic',
+        gateCounts: 'deterministic',
+        gas: 'deterministic',
+        witgenMs: 'hardware-dependent',
+        provingTime: 'hardware-dependent',
+      },
       systemInfo,
     };
 
@@ -129,6 +161,21 @@ export class Profiler {
       console.error(`Error writing results to ${filename}:`, error.message);
       throw error;
     }
+  }
+
+  /**
+   * Builds region summaries: for each region, a map of function name → total gate count in that region.
+   */
+  #buildRegionSummaries(results: ProfileResult[]): Record<string, Record<string, number>> {
+    const summaries: Record<string, Record<string, number>> = {};
+    for (const result of results) {
+      if (!result.regions) continue;
+      for (const [regionName, regionResult] of Object.entries(result.regions)) {
+        if (!summaries[regionName]) summaries[regionName] = {};
+        summaries[regionName][result.name] = regionResult.totalGateCount;
+      }
+    }
+    return summaries;
   }
 
   /**
@@ -206,6 +253,7 @@ export class Profiler {
         gateCounts: profileResults.executionSteps.map(step => ({
           circuitName: step.functionName,
           gateCount: step.gateCount || 0,
+          witgenMs: step.timings?.witgen,
         })),
         gas,
         provingTime,
@@ -221,4 +269,60 @@ export class Profiler {
       throw error;
     }
   }
-} 
+
+  /**
+   * Profiles a raw interaction that manages its own simulate/profile/send lifecycle.
+   * Does NOT inject fee options, origin, or additional scopes — the action handles everything.
+   * @param item - The raw benchmarked interaction.
+   * @returns A promise that resolves to a profile result.
+   * @private
+   */
+  async #profileOneRaw(item: RawBenchmarkedInteraction): Promise<ProfileResult> {
+    const name = item.name;
+    console.log(`Profiling ${name} (raw interaction)...`);
+
+    try {
+      // 1. Simulate — action manages its own options
+      const simResult = await item.action.simulate();
+      const gas: GasLimits | undefined = simResult?.estimatedGas;
+
+      // 2. Profile — action manages its own options
+      const profileResults = await item.action.profile({
+        profileMode: 'full',
+        skipProofGeneration: this.#skipProving,
+      });
+
+      const provingTime = !this.#skipProving
+        ? profileResults.stats?.timings?.proving
+        : undefined;
+
+      // 3. Send — action manages its own options
+      await item.action.send();
+
+      const result: ProfileResult = {
+        name,
+        totalGateCount: sumArray(
+          profileResults.executionSteps
+            .map((step: any) => step.gateCount)
+            .filter((count: any): count is number => count !== undefined),
+        ),
+        gateCounts: profileResults.executionSteps.map((step: any) => ({
+          circuitName: step.functionName,
+          gateCount: step.gateCount || 0,
+          witgenMs: step.timings?.witgen,
+        })),
+        gas,
+        provingTime,
+      };
+
+      const daGas = gas?.gasLimits?.daGas ?? 'N/A';
+      const l2Gas = gas?.gasLimits?.l2Gas ?? 'N/A';
+      const provingDisplay = provingTime !== undefined ? `${provingTime}ms` : 'skipped';
+      console.log(` -> ${name}: ${result.totalGateCount} gates, Gas (DA: ${daGas}, L2: ${l2Gas}), Proving: ${provingDisplay}`);
+      return result;
+    } catch (error: any) {
+      console.error(`Error profiling ${name}:`, error.message);
+      throw error;
+    }
+  }
+}

--- a/cli/rawInteraction.ts
+++ b/cli/rawInteraction.ts
@@ -1,0 +1,59 @@
+import type { AztecAddress } from '@aztec/aztec.js/addresses';
+
+/**
+ * Duck-type interface for actions that manage their own simulate/profile/send lifecycle.
+ *
+ * Use this when the standard ContractFunctionInteraction flow doesn't apply —
+ * for example, when the contract under test must be the transaction root
+ * (msg_sender = None), bypassing the account entrypoint.
+ *
+ * The profiler calls these methods directly without injecting fee options,
+ * origin address, or additional scopes — your implementation handles all of that.
+ */
+export interface ProfileableAction {
+  /** Optional: return an execution payload or request for name discovery. */
+  request?(): any;
+  /** Simulate the transaction. Should return an object with `estimatedGas` if gas tracking is desired. */
+  simulate(opts?: any): Promise<any>;
+  /** Profile the transaction. Should return a TxProfileResult-compatible object with executionSteps and stats. */
+  profile(opts?: any): Promise<any>;
+  /** Send the transaction on-chain. */
+  send(opts?: any): Promise<any>;
+}
+
+/**
+ * A benchmark interaction using a raw (duck-typed) action.
+ *
+ * Unlike NamedBenchmarkedInteraction which wraps a ContractFunctionInteractionCallIntent,
+ * this type allows arbitrary action objects that implement simulate/profile/send.
+ * The profiler will NOT inject fee options or origin — the action manages everything.
+ *
+ * Example use case: cold-start FPC where the contract is the tx root and you need
+ * to construct TxExecutionRequest manually, calling PXE APIs directly.
+ */
+export interface RawBenchmarkedInteraction {
+  /** The duck-typed action implementing simulate/profile/send. */
+  action: ProfileableAction;
+  /** The caller address (used for logging/reporting, not injected into the action). */
+  caller: AztecAddress;
+  /** Display name for this benchmark entry in reports. Required for raw interactions. */
+  name: string;
+  /** Extra addresses whose private state should be accessible during execution. */
+  additionalScopes?: AztecAddress[];
+}
+
+/**
+ * Type guard to distinguish RawBenchmarkedInteraction from other interaction types.
+ *
+ * Detection: has 'action' and 'name' directly (not nested under 'interaction'),
+ * and does NOT have 'interaction' (which NamedBenchmarkedInteraction has).
+ */
+export function isRawInteraction(item: any): item is RawBenchmarkedInteraction {
+  return (
+    item != null &&
+    typeof item === 'object' &&
+    'action' in item &&
+    'name' in item &&
+    !('interaction' in item)
+  );
+}

--- a/cli/traceRegions.ts
+++ b/cli/traceRegions.ts
@@ -1,0 +1,129 @@
+import type { GateCount } from './types.js';
+
+/** Defines a named region of the execution trace to extract and report separately. */
+export interface TraceRegion {
+  /** Display name for this region in reports (e.g., 'fpc-only', 'app', 'kernel'). */
+  name: string;
+  /** Contract name prefix(es) marking the first step of this region. */
+  startMatch: string | string[];
+  /** Contract name prefix(es) marking the end boundary (exclusive). Omit to include until end of trace. */
+  endMatch?: string | string[];
+  /** If true, filter out kernel circuits (private_kernel_*, hiding_kernel) from the extracted region. */
+  excludeKernels?: boolean;
+}
+
+/** Result of extracting a trace region: the filtered gate counts and their total. */
+export interface RegionResult {
+  /** Sum of gate counts in this region. */
+  totalGateCount: number;
+  /** Per-circuit gate counts within this region. */
+  gateCounts: GateCount[];
+}
+
+const KERNEL_PATTERN_PREFIX = 'private_kernel_';
+const KERNEL_EXACT = 'hiding_kernel';
+
+/** Returns true if the circuit name is a kernel circuit (private_kernel_* or hiding_kernel). */
+export function isKernelCircuit(name: string): boolean {
+  return name.startsWith(KERNEL_PATTERN_PREFIX) || name === KERNEL_EXACT;
+}
+
+function toArray(value: string | string[]): string[] {
+  return Array.isArray(value) ? value : [value];
+}
+
+function matchesAny(name: string, prefixes: string[]): boolean {
+  return prefixes.some(prefix => name.startsWith(prefix));
+}
+
+/**
+ * Extracts a slice of execution steps matching a trace region definition.
+ *
+ * Algorithm (proven in FPC's extractFpcSteps):
+ * 1. Find first step where circuitName starts with any startMatch prefix
+ * 2. Find first step after that matching any endMatch prefix (or end of trace)
+ * 3. Optionally filter out kernel circuits
+ */
+export function extractRegion(steps: GateCount[], region: TraceRegion): GateCount[] {
+  const startPrefixes = toArray(region.startMatch);
+
+  const startIdx = steps.findIndex(s => matchesAny(s.circuitName, startPrefixes));
+  if (startIdx === -1) return [];
+
+  let endIdx = steps.length;
+  if (region.endMatch) {
+    const endPrefixes = toArray(region.endMatch);
+    for (let i = startIdx; i < steps.length; i++) {
+      if (matchesAny(steps[i].circuitName, endPrefixes)) {
+        endIdx = i;
+        break;
+      }
+    }
+  }
+
+  let sliced = steps.slice(startIdx, endIdx);
+
+  if (region.excludeKernels) {
+    sliced = sliced.filter(s => !isKernelCircuit(s.circuitName));
+  }
+
+  return sliced;
+}
+
+/** Extracts only kernel circuits from the full trace. */
+export function extractKernelOverhead(steps: GateCount[]): GateCount[] {
+  return steps.filter(s => isKernelCircuit(s.circuitName));
+}
+
+/** Extracts only non-kernel (application) circuits from the full trace. */
+export function extractAppLogic(steps: GateCount[]): GateCount[] {
+  return steps.filter(s => !isKernelCircuit(s.circuitName));
+}
+
+/**
+ * Returns a built-in region preset that splits the trace into "app" (non-kernel)
+ * and "kernel" (kernel overhead) regions. No configuration needed.
+ */
+export function kernelIsolation(): TraceRegion[] {
+  // These are synthetic regions handled specially by applyRegions —
+  // they use the full trace and filter by kernel vs non-kernel.
+  return [
+    { name: 'app', startMatch: '__all__', excludeKernels: true },
+    { name: 'kernel', startMatch: '__all__', excludeKernels: false },
+  ];
+}
+
+function sumGateCounts(steps: GateCount[]): number {
+  return steps.reduce((sum, s) => sum + (s.gateCount ?? 0), 0);
+}
+
+/**
+ * Applies an array of region definitions to a list of gate counts,
+ * returning a map of region name → RegionResult.
+ */
+export function applyRegions(
+  gateCounts: GateCount[],
+  regions: TraceRegion[],
+): Record<string, RegionResult> {
+  const result: Record<string, RegionResult> = {};
+
+  for (const region of regions) {
+    let extracted: GateCount[];
+
+    if (region.startMatch === '__all__') {
+      // Synthetic region: filter the full trace
+      extracted = region.excludeKernels
+        ? extractAppLogic(gateCounts)
+        : extractKernelOverhead(gateCounts);
+    } else {
+      extracted = extractRegion(gateCounts, region);
+    }
+
+    result[region.name] = {
+      totalGateCount: sumGateCounts(extracted),
+      gateCounts: extracted,
+    };
+  }
+
+  return result;
+}

--- a/cli/types.ts
+++ b/cli/types.ts
@@ -3,8 +3,14 @@ import type { ContractFunctionInteractionCallIntent } from '@aztec/aztec.js/auth
 import type { FeePaymentMethod } from '@aztec/aztec.js/fee';
 import { EmbeddedWallet } from '@aztec/wallets/embedded';
 import type { SystemInfo } from './systemInfo.js';
+import type { TraceRegion, RegionResult } from './traceRegions.js';
+import type { RawBenchmarkedInteraction, ProfileableAction } from './rawInteraction.js';
+import type { MetricThresholds, ComparisonEntry, ComparisonResult } from './comparison.js';
 
 export type { SystemInfo } from './systemInfo.js';
+export type { TraceRegion, RegionResult } from './traceRegions.js';
+export type { RawBenchmarkedInteraction, ProfileableAction } from './rawInteraction.js';
+export type { MetricThresholds, ComparisonEntry, ComparisonResult } from './comparison.js';
 
 /** Simplified Gas type (contains actual gas values) */
 export type Gas = {
@@ -35,6 +41,8 @@ export interface GateCount {
   circuitName: string;
   /** The number of gates in the circuit. */
   gateCount: number;
+  /** Witness generation time in ms (hardware-dependent). */
+  witgenMs?: number;
 }
 
 /** Result of profiling a single function */
@@ -49,6 +57,8 @@ export interface ProfileResult {
   gas?: GasLimits;
   /** Proving time in milliseconds. */
   provingTime?: number;
+  /** Per-region gate count breakdowns (present when benchmark defines getRegions()). */
+  regions?: Record<string, RegionResult>;
 }
 
 /** Defines a contract interaction to be benchmarked, with a custom display name. */
@@ -61,6 +71,12 @@ export interface NamedBenchmarkedInteraction {
   additionalScopes?: AztecAddress[];
 }
 
+/** Union of all interaction types accepted by the profiler. */
+export type BenchmarkableItem =
+  | ContractFunctionInteractionCallIntent
+  | NamedBenchmarkedInteraction
+  | RawBenchmarkedInteraction;
+
 /** Structure of the output JSON report */
 export interface ProfileReport {
   /** Total gate counts keyed by function name */
@@ -71,6 +87,10 @@ export interface ProfileReport {
   gasSummary: Record<string, number>;
   /** Proving time summary (in ms) keyed by function name */
   provingTimeSummary: Record<string, number>;
+  /** Per-region total gate counts: region name → function name → total gates. */
+  regionSummaries?: Record<string, Record<string, number>>;
+  /** Metric stability annotations: which metrics are deterministic vs hardware-dependent. */
+  metricStability?: Record<string, 'deterministic' | 'hardware-dependent'>;
   /** System information where the benchmark was run */
   systemInfo: SystemInfo;
 }
@@ -79,8 +99,10 @@ export interface ProfileReport {
 export abstract class BenchmarkBase {
   /** Optional setup function run before benchmarks */
   abstract setup?(): Promise<BenchmarkContext>;
-  /** Function returning the methods to benchmark. Can be a mix of plain interactions or named interactions. */
-  abstract getMethods(context: BenchmarkContext): Array<ContractFunctionInteractionCallIntent | NamedBenchmarkedInteraction>;
+  /** Function returning the methods to benchmark. Can be a mix of plain interactions, named interactions, or raw interactions. */
+  abstract getMethods(context: BenchmarkContext): BenchmarkableItem[];
   /** Optional teardown function run after benchmarks (no longer abstract) */
   teardown?(context: BenchmarkContext): Promise<void>;
+  /** Optional: define named trace regions for per-region gate count breakdown. */
+  getRegions?(): TraceRegion[];
 } 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -1,0 +1,282 @@
+# Quick Start: Benchmarking Aztec Smart Contracts
+
+Get gate counts, gas estimates, and performance metrics for your Aztec contracts in under 10 minutes.
+
+## Prerequisites
+
+- **Node.js 22+**
+- **Running Aztec sandbox** (`aztec start --sandbox`)
+- **Compiled contracts** (`aztec compile`)
+
+## 1. Install
+
+```sh
+yarn add --dev @defi-wonderland/aztec-benchmark
+```
+
+## 2. Configure
+
+Add a `[benchmark]` section to your `Nargo.toml`:
+
+```toml
+[benchmark]
+my_contract = "benchmarks/my_contract.benchmark.ts"
+```
+
+The path is relative to the `Nargo.toml` file.
+
+## 3. Write Your First Benchmark
+
+Create `benchmarks/my_contract.benchmark.ts`:
+
+```ts
+import { Benchmark, type BenchmarkContext } from '@defi-wonderland/aztec-benchmark';
+import { createAztecNodeClient, waitForNode } from '@aztec/aztec.js/node';
+import { Contract } from '@aztec/aztec.js/contracts';
+import { createPXE, getPXEConfig } from '@aztec/pxe/server';
+import { loadContractArtifact } from '@aztec/stdlib/abi';
+import { readFileSync } from 'fs';
+
+export default class MyContractBenchmark extends Benchmark {
+  async setup() {
+    const node = createAztecNodeClient('http://localhost:8080');
+    await waitForNode(node);
+    const pxe = await createPXE(node, {
+      ...getPXEConfig(),
+      l1Contracts: await node.getL1ContractAddresses(),
+    });
+
+    // Register accounts, deploy contracts, mint tokens, etc.
+    // ...
+
+    return { wallet, pxe };
+  }
+
+  getMethods(context) {
+    const { contract, userAddress } = context;
+    return [
+      // Auto-derived name from the method
+      { caller: userAddress, action: contract.methods.transfer(recipient, 100n) },
+
+      // Or specify a custom name
+      {
+        interaction: { caller: userAddress, action: contract.methods.mint(userAddress, 1000n) },
+        name: 'mint_1000',
+      },
+    ];
+  }
+
+  async teardown(context) {
+    // Optional cleanup
+  }
+}
+```
+
+## 4. Run
+
+```sh
+npx aztec-benchmark
+```
+
+Run a specific contract:
+```sh
+npx aztec-benchmark --contracts my_contract
+```
+
+Skip proving (faster, still measures gates and gas):
+```sh
+npx aztec-benchmark --skip-proving
+```
+
+## 5. Read Results
+
+The profiler writes a JSON report to `./benchmarks/my_contract.benchmark.json`:
+
+```json
+{
+  "summary": { "transfer": 45230, "mint_1000": 32100 },
+  "results": [
+    {
+      "name": "transfer",
+      "totalGateCount": 45230,
+      "gateCounts": [
+        { "circuitName": "private_kernel_init", "gateCount": 15000, "witgenMs": 12.3 },
+        { "circuitName": "Token:transfer", "gateCount": 18230, "witgenMs": 45.1 },
+        { "circuitName": "private_kernel_tail", "gateCount": 12000, "witgenMs": 8.7 }
+      ],
+      "gas": {
+        "gasLimits": { "daGas": 1200, "l2Gas": 450000 },
+        "teardownGasLimits": { "daGas": 0, "l2Gas": 0 }
+      },
+      "provingTime": 2500
+    }
+  ],
+  "gasSummary": { "transfer": 451200, "mint_1000": 380000 },
+  "provingTimeSummary": { "transfer": 2500, "mint_1000": 1800 },
+  "systemInfo": { "cpuModel": "...", "cpuCores": 16, "totalMemoryGiB": 64, "arch": "x64" }
+}
+```
+
+**Key metrics:**
+- **Gate count** (deterministic) -- total circuit complexity, main regression indicator
+- **DA gas / L2 gas** (deterministic) -- on-chain cost
+- **witgenMs** (hardware-dependent) -- witness generation time per circuit
+- **provingTime** (hardware-dependent) -- total proving time
+
+## 6. Add CI
+
+Add two workflow files to get automatic PR regression detection:
+
+**`.github/workflows/update-baseline.yml`** -- runs on push to main:
+```yaml
+name: Update Benchmark Baseline
+on:
+  push:
+    branches: [main, dev]
+jobs:
+  benchmark:
+    uses: defi-wonderland/aztec-benchmark/.github/workflows/update-baseline.yml@v0
+    permissions:
+      contents: read
+      actions: write
+```
+
+**`.github/workflows/pr-checks.yml`** -- runs on PRs:
+```yaml
+name: PR Benchmark
+on:
+  pull_request:
+    branches: [main, dev]
+jobs:
+  benchmark:
+    uses: defi-wonderland/aztec-benchmark/.github/workflows/pr-benchmark.yml@v0
+    permissions:
+      pull-requests: write
+      issues: write
+      actions: read
+```
+
+PRs will get a comment showing gate count, gas, and proving time diffs with regression indicators.
+
+## 7. Configure Thresholds
+
+By default, a 2.5% change in gates, DA gas, or L2 gas triggers a regression flag. Proving time is info-only (shown but doesn't trigger regression since it's hardware-dependent).
+
+For tighter control, set per-metric thresholds in your workflow:
+
+```yaml
+jobs:
+  benchmark:
+    uses: defi-wonderland/aztec-benchmark/.github/workflows/pr-benchmark.yml@v0
+    with:
+      thresholds: '{"gates": 1.0, "daGas": 2.5, "l2Gas": 2.5, "provingTime": null}'
+```
+
+| Value | Meaning |
+|-------|---------|
+| `1.0` | Flag as regression if metric changes by more than 1% |
+| `null` | Info-only: show the metric but never flag it |
+
+Reports also include a `metricStability` field annotating each metric as `"deterministic"` (gates, gas) or `"hardware-dependent"` (witgenMs, provingTime).
+
+---
+
+## Advanced: Trace Regions
+
+Transaction traces include kernel overhead (private_kernel_init, private_kernel_inner, etc.) alongside your contract logic. To isolate specific portions, define regions:
+
+```ts
+import { Benchmark, kernelIsolation } from '@defi-wonderland/aztec-benchmark';
+
+export default class MyBenchmark extends Benchmark {
+  getRegions() {
+    // Built-in: splits trace into "app" and "kernel" regions
+    return kernelIsolation();
+  }
+
+  // Or define custom regions:
+  getRegions() {
+    return [
+      {
+        name: 'fpc-only',
+        startMatch: ['FPC:', 'FPCMultiAsset:'],
+        endMatch: 'Noop:',
+      },
+      {
+        name: 'app-no-kernels',
+        startMatch: 'Token:',
+        excludeKernels: true,
+      },
+    ];
+  }
+}
+```
+
+Region results appear in the JSON report under `regions` and `regionSummaries`, and in PR comments as a collapsible breakdown section.
+
+## Advanced: Custom Transaction Flows
+
+For contracts that must be the transaction root (bypassing the account entrypoint), use raw interactions:
+
+```ts
+import { Benchmark } from '@defi-wonderland/aztec-benchmark';
+
+export default class ColdStartBenchmark extends Benchmark {
+  async setup() {
+    // Build a TxExecutionRequest manually
+    // ...
+    const action = {
+      async simulate() {
+        const sim = await pxe.simulateTx(txRequest, { simulatePublic: true, scopes: signers });
+        return { estimatedGas: { gasLimits: { daGas: ..., l2Gas: ... }, teardownGasLimits: { daGas: 0, l2Gas: 0 } } };
+      },
+      async profile(opts) {
+        return await pxe.profileTx(txRequest, { profileMode: 'full', scopes: signers, ...opts });
+      },
+      async send() {
+        const result = await pxe.proveTx(txRequest, signers);
+        const tx = await result.toTx();
+        await node.sendTx(tx);
+      },
+    };
+    return { wallet: undefined, _action: action, userAddress };
+  }
+
+  getMethods(context) {
+    return [{
+      action: context._action,
+      caller: context.userAddress,
+      name: 'cold_start_entrypoint',
+    }];
+  }
+}
+```
+
+The profiler calls `simulate()`, `profile()`, and `send()` directly on your action without injecting fee options.
+
+## Advanced: Fee Payment
+
+If your accounts don't have pre-existing Fee Juice, return a `feePaymentMethod` from `setup()`:
+
+```ts
+async setup() {
+  // Using the sandbox's built-in SponsoredFPC
+  const feePaymentMethod = new SponsoredFeePaymentMethod(sponsoredFpcAddress);
+  return { wallet, feePaymentMethod };
+}
+```
+
+For custom FPCs, use `FeeWrappedInteraction` to inject per-interaction fee payment:
+
+```ts
+import { namedMethod } from '@defi-wonderland/aztec-benchmark';
+
+getMethods(context) {
+  return [
+    namedMethod('transfer_with_fpc', context.userAddress, contract.methods.transfer(...), {
+      paymentMethod: myFpcPaymentMethod,
+      gasSettings: customGasSettings,
+    }),
+  ];
+}
+```

--- a/examples/Nargo.toml
+++ b/examples/Nargo.toml
@@ -1,0 +1,2 @@
+[benchmark]
+mock = "mock.benchmark.ts"

--- a/examples/mock.benchmark.ts
+++ b/examples/mock.benchmark.ts
@@ -1,0 +1,92 @@
+/**
+ * Mock benchmark that exercises the full profiler pipeline WITHOUT a running sandbox.
+ *
+ * Uses RawBenchmarkedInteraction with a fake action that returns canned profile data.
+ * Tests: raw interaction handling, witgenMs capture, trace region extraction, JSON output.
+ *
+ * Run with:
+ *   npx aztec-benchmark --config examples/Nargo.toml --skip-proving -o examples/output
+ */
+
+import { AztecAddress } from '@aztec/aztec.js/addresses';
+
+// Fake execution steps simulating a realistic FPC-style transaction trace.
+// The profiler will capture gateCount and timings.witgen from each step.
+const MOCK_EXECUTION_STEPS = [
+  { functionName: 'private_kernel_init', gateCount: 25000, bytecode: Buffer.alloc(0), witness: new Map(), vk: Buffer.alloc(0), timings: { witgen: 15.2 } },
+  { functionName: 'SchnorrAccount:entrypoint', gateCount: 18000, bytecode: Buffer.alloc(0), witness: new Map(), vk: Buffer.alloc(0), timings: { witgen: 22.5 } },
+  { functionName: 'private_kernel_inner', gateCount: 30000, bytecode: Buffer.alloc(0), witness: new Map(), vk: Buffer.alloc(0), timings: { witgen: 10.1 } },
+  { functionName: 'FPC:fee_entrypoint', gateCount: 45000, bytecode: Buffer.alloc(0), witness: new Map(), vk: Buffer.alloc(0), timings: { witgen: 55.3 } },
+  { functionName: 'Token:transfer_private_to_private', gateCount: 32000, bytecode: Buffer.alloc(0), witness: new Map(), vk: Buffer.alloc(0), timings: { witgen: 40.7 } },
+  { functionName: 'private_kernel_inner', gateCount: 30000, bytecode: Buffer.alloc(0), witness: new Map(), vk: Buffer.alloc(0), timings: { witgen: 10.0 } },
+  { functionName: 'Noop:noop', gateCount: 5000, bytecode: Buffer.alloc(0), witness: new Map(), vk: Buffer.alloc(0), timings: { witgen: 3.2 } },
+  { functionName: 'private_kernel_inner', gateCount: 30000, bytecode: Buffer.alloc(0), witness: new Map(), vk: Buffer.alloc(0), timings: { witgen: 10.0 } },
+  { functionName: 'private_kernel_tail', gateCount: 20000, bytecode: Buffer.alloc(0), witness: new Map(), vk: Buffer.alloc(0), timings: { witgen: 8.5 } },
+];
+
+/** Mock action that returns canned profile data — no sandbox needed. */
+class MockAction {
+  async simulate() {
+    return {
+      estimatedGas: {
+        gasLimits: { daGas: 1500, l2Gas: 560000 },
+        teardownGasLimits: { daGas: 0, l2Gas: 0 },
+      },
+    };
+  }
+
+  async profile() {
+    return {
+      executionSteps: MOCK_EXECUTION_STEPS,
+      stats: {
+        timings: {
+          proving: 4200,
+          perFunction: MOCK_EXECUTION_STEPS.map(s => ({
+            functionName: s.functionName,
+            time: s.timings.witgen,
+          })),
+          unaccounted: 50,
+          total: 4250,
+        },
+      },
+    };
+  }
+
+  async send() {
+    // No-op: nothing to send in mock mode
+  }
+}
+
+export default class MockBenchmark {
+  getRegions() {
+    return [
+      {
+        name: 'fpc-only',
+        startMatch: 'FPC:',
+        endMatch: 'Noop:',
+      },
+      {
+        name: 'fpc-no-kernels',
+        startMatch: 'FPC:',
+        endMatch: 'Noop:',
+        excludeKernels: true,
+      },
+    ];
+  }
+
+  async setup() {
+    return {};
+  }
+
+  getMethods() {
+    return [
+      {
+        action: new MockAction(),
+        caller: AztecAddress.fromBigInt(1n),
+        name: 'fee_entrypoint',
+      },
+    ];
+  }
+
+  async teardown() {}
+}


### PR DESCRIPTION
Phase 1 | Core profiling features:
- Declarative trace regions via getRegions() with startMatch/endMatch/excludeKernels
- Built-in kernelIsolation() preset for app vs kernel gate breakdown
- Raw TxExecutionRequest support via RawBenchmarkedInteraction for non-standard tx flows
- Per-circuit witness generation timing (witgenMs) captured from SDK
- Per-region regression detection in PR comparison comments

Phase 2 | CI and programmatic API:
- Configurable per-metric thresholds (gates, daGas, l2Gas, provingTime)
- Metric stability annotations (deterministic vs hardware-dependent)
- Programmatic compareReports() API for in-memory report comparison

Also includes documentation (README, QUICK_START guide), mock benchmark example, and ROADMAP with full feature catalog and implementation status.