### PR TITLE
feat: add per-circuit witness generation timing

### DIFF
--- a/cli/profiler.ts
+++ b/cli/profiler.ts
@@ -206,6 +206,7 @@ export class Profiler {
         gateCounts: profileResults.executionSteps.map(step => ({
           circuitName: step.functionName,
           gateCount: step.gateCount || 0,
+          witgenMs: step.timings?.witgen,
         })),
         gas,
         provingTime,

--- a/cli/types.ts
+++ b/cli/types.ts
@@ -35,6 +35,8 @@ export interface GateCount {
   circuitName: string;
   /** The number of gates in the circuit. */
   gateCount: number;
+  /** Witness generation time in ms (hardware-dependent). */
+  witgenMs?: number;
 }
 
 /** Result of profiling a single function */


### PR DESCRIPTION
- Captures `witgenMs` (witness generation time in ms) for each circuit step in  benchmark reports. The SDK already provides this data via `PrivateExecutionStep.timings.witgen`
- Adds optional `witgenMs` field to the `GateCount` interface. 