### PR TITLE
feat: add trace regions to isolate and profile specific sections of the execution trace

### DIFF
--- a/action/comparison.cjs
+++ b/action/comparison.cjs
@@ -189,6 +189,74 @@ function generateCircuitBreakdownSection(comparison, sortedNames, contractName) 
 }
 
 /**
+ * Generates a collapsible section showing per-region gate count comparisons.
+ * @param {object} comparison - The comparison object keyed by function name.
+ * @param {string[]} sortedNames - Sorted function names.
+ * @param {number} threshold - Regression threshold percentage.
+ * @param {string} contractName - The contract name for the section header.
+ * @returns {string} HTML string with collapsible region comparisons, or empty string if no region data.
+ */
+function generateRegionComparisonSection(comparison, sortedNames, threshold, contractName) {
+  const hasRegionData = sortedNames.some(name => {
+    const regions = comparison[name]?.regions;
+    return regions && (Object.keys(regions.pr).length > 0 || Object.keys(regions.main).length > 0);
+  });
+  if (!hasRegionData) return '';
+
+  const allRegionNames = new Set();
+  for (const funcName of sortedNames) {
+    const regions = comparison[funcName]?.regions;
+    if (regions) {
+      for (const name of Object.keys(regions.main)) allRegionNames.add(name);
+      for (const name of Object.keys(regions.pr)) allRegionNames.add(name);
+    }
+  }
+
+  if (allRegionNames.size === 0) return '';
+
+  const lines = [
+    '<details>',
+    `<summary>📊 ${contractName} region breakdown</summary>`,
+    '',
+  ];
+
+  for (const regionName of [...allRegionNames].sort()) {
+    lines.push(
+      `#### Region: \`${regionName}\``,
+      '',
+      '| 🚦 | Function | Base Gates | PR Gates | Diff |',
+      '|:---:|----------|----------:|--------:|------|',
+    );
+
+    for (const funcName of sortedNames) {
+      const regions = comparison[funcName]?.regions;
+      const mainRegion = regions?.main?.[regionName];
+      const prRegion = regions?.pr?.[regionName];
+
+      const mainGates = mainRegion?.totalGateCount ?? 0;
+      const prGates = prRegion?.totalGateCount ?? 0;
+
+      const regionMetrics = {
+        gates: { main: mainGates, pr: prGates },
+        daGas: { main: 0, pr: 0 },
+        l2Gas: { main: 0, pr: 0 },
+      };
+      const emoji = getStatusEmoji(regionMetrics, threshold);
+      const diff = formatDiff(mainGates, prGates);
+
+      lines.push(
+        `| ${emoji} | \`${funcName}\` | ${mainGates.toLocaleString()} | ${prGates.toLocaleString()} | ${diff} |`,
+      );
+    }
+
+    lines.push('');
+  }
+
+  lines.push('</details>');
+  return lines.join('\n');
+}
+
+/**
  * Generates an HTML table comparing benchmark results for a single contract.
  * Handles new contracts where baseJsonPath may be null (no base report exists).
  * @param {object} pair - An object containing contractName, baseJsonPath (or null), and prJsonPath.
@@ -252,6 +320,7 @@ function generateContractComparisonTable(pair, threshold, { circuitDetails = fal
       l2Gas: { main: getL2Gas(mainResult), pr: getL2Gas(prResult) },
       provingTime: { main: getProvingTime(mainResult), pr: getProvingTime(prResult) },
       gateCounts: { main: mainResult?.gateCounts ?? [], pr: prResult?.gateCounts ?? [] },
+      regions: { main: mainResult?.regions ?? {}, pr: prResult?.regions ?? {} },
     };
   }
 
@@ -333,6 +402,12 @@ function generateContractComparisonTable(pair, threshold, { circuitDetails = fal
     if (circuitSection) {
       output.push('', circuitSection);
     }
+  }
+
+  // Add per-region comparison sections if any results have region data
+  const regionSection = generateRegionComparisonSection(comparison, sortedNames, threshold, contractName);
+  if (regionSection) {
+    output.push('', regionSection);
   }
 
   return output.join('\n');

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -129,7 +129,11 @@ program
           process.exit(1);
         }
 
-        const profiler = new Profiler(runContext.wallet, { skipProving: options.skipProving, feePaymentMethod: runContext.feePaymentMethod });
+        const regions = typeof benchmarkInstance.getRegions === 'function'
+          ? benchmarkInstance.getRegions()
+          : undefined;
+
+        const profiler = new Profiler(runContext.wallet, { skipProving: options.skipProving, feePaymentMethod: runContext.feePaymentMethod, regions });
 
         console.log(`Getting methods to benchmark for ${contractName}...`);
         const interactionsToBenchmark: Array<ContractFunctionInteractionCallIntent | NamedBenchmarkedInteraction> = benchmarkInstance.getMethods(runContext);

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,6 +1,6 @@
 // Export the base class and types for users
 export { BenchmarkBase as Benchmark, BenchmarkContext } from './types.js'; // Alias BenchmarkBase to Benchmark for user convenience
-export type { ProfileReport, ProfileResult, GateCount, SystemInfo, NamedBenchmarkedInteraction } from './types.js';
+export type { ProfileReport, ProfileResult, GateCount, SystemInfo, NamedBenchmarkedInteraction, TraceRegion, RegionResult } from './types.js';
 
 // Export system info utilities
 export { getSystemInfo } from './systemInfo.js';
@@ -11,3 +11,6 @@ export { Profiler } from './profiler.js';
 // Export fee payment helpers
 export { FeeWrappedInteraction, namedMethod } from './feeWrappedInteraction.js';
 export type { FeeGasSettings, FeeOptions } from './feeWrappedInteraction.js';
+
+// Trace region utilities
+export { extractRegion, extractKernelOverhead, extractAppLogic, applyRegions, kernelIsolation, isKernelCircuit } from './traceRegions.js';

--- a/cli/profiler.ts
+++ b/cli/profiler.ts
@@ -12,6 +12,7 @@ import {
   type NamedBenchmarkedInteraction,
 } from './types.js';
 import { getSystemInfo } from './systemInfo.js';
+import { applyRegions, type TraceRegion } from './traceRegions.js';
 
 /**
  * Sums all numbers in an array.
@@ -35,6 +36,8 @@ interface ProfilerOptions {
   skipProving?: boolean;
   /** Fee payment method to use when sending transactions. */
   feePaymentMethod?: FeePaymentMethod;
+  /** Trace regions to extract per-region gate count breakdowns. */
+  regions?: TraceRegion[];
 }
 
 /**
@@ -43,11 +46,13 @@ interface ProfilerOptions {
 export class Profiler {
   #skipProving: boolean;
   #feePaymentMethod?: FeePaymentMethod;
+  #regions?: TraceRegion[];
 
   /** @param _wallet - Unused, kept for backward compatibility with existing callers. */
   constructor(_wallet?: EmbeddedWallet, options?: ProfilerOptions) {
     this.#skipProving = options?.skipProving ?? false;
     this.#feePaymentMethod = options?.feePaymentMethod;
+    this.#regions = options?.regions;
   }
 
   /**
@@ -114,11 +119,25 @@ export class Profiler {
       {} as Record<string, number>,
     );
 
+    // Apply trace region extraction if regions are configured
+    if (this.#regions?.length) {
+      for (const result of results) {
+        if (result.gateCounts.length) {
+          result.regions = applyRegions(result.gateCounts, this.#regions);
+        }
+      }
+    }
+
+    const regionSummaries = this.#regions?.length
+      ? this.#buildRegionSummaries(results)
+      : undefined;
+
     const report: ProfileReport = {
       summary,
       results: results,
       gasSummary,
       provingTimeSummary,
+      regionSummaries,
       systemInfo,
     };
 
@@ -129,6 +148,21 @@ export class Profiler {
       console.error(`Error writing results to ${filename}:`, error.message);
       throw error;
     }
+  }
+
+  /**
+   * Builds region summaries: for each region, a map of function name -> total gate count in that region.
+   */
+  #buildRegionSummaries(results: ProfileResult[]): Record<string, Record<string, number>> {
+    const summaries: Record<string, Record<string, number>> = {};
+    for (const result of results) {
+      if (!result.regions) continue;
+      for (const [regionName, regionResult] of Object.entries(result.regions)) {
+        if (!summaries[regionName]) summaries[regionName] = {};
+        summaries[regionName][result.name] = regionResult.totalGateCount;
+      }
+    }
+    return summaries;
   }
 
   /**

--- a/cli/traceRegions.ts
+++ b/cli/traceRegions.ts
@@ -1,0 +1,126 @@
+import type { GateCount } from './types.js';
+
+/** Defines a named region of the execution trace to extract and report separately. */
+export interface TraceRegion {
+  /** Display name for this region in reports (e.g., 'fpc-only', 'app', 'kernel'). */
+  name: string;
+  /** Contract name prefix(es) marking the first step of this region. */
+  startMatch: string | string[];
+  /** Contract name prefix(es) marking the end boundary (exclusive). Omit to include until end of trace. */
+  endMatch?: string | string[];
+  /** If true, filter out kernel circuits (private_kernel_*, hiding_kernel) from the extracted region. */
+  excludeKernels?: boolean;
+}
+
+/** Result of extracting a trace region: the filtered gate counts and their total. */
+export interface RegionResult {
+  /** Sum of gate counts in this region. */
+  totalGateCount: number;
+  /** Per-circuit gate counts within this region. */
+  gateCounts: GateCount[];
+}
+
+const KERNEL_PATTERN_PREFIX = 'private_kernel_';
+const KERNEL_EXACT = 'hiding_kernel';
+
+/** Returns true if the circuit name is a kernel circuit (private_kernel_* or hiding_kernel). */
+export function isKernelCircuit(name: string): boolean {
+  return name.startsWith(KERNEL_PATTERN_PREFIX) || name === KERNEL_EXACT;
+}
+
+function toArray(value: string | string[]): string[] {
+  return Array.isArray(value) ? value : [value];
+}
+
+function matchesAny(name: string, prefixes: string[]): boolean {
+  return prefixes.some(prefix => name.startsWith(prefix));
+}
+
+/**
+ * Extracts a slice of execution steps matching a trace region definition.
+ *
+ * 1. Find first step where circuitName starts with any startMatch prefix
+ * 2. Find first step after that matching any endMatch prefix (or end of trace)
+ * 3. Optionally filter out kernel circuits
+ */
+export function extractRegion(steps: GateCount[], region: TraceRegion): GateCount[] {
+  const startPrefixes = toArray(region.startMatch);
+
+  const startIdx = steps.findIndex(s => matchesAny(s.circuitName, startPrefixes));
+  if (startIdx === -1) return [];
+
+  let endIdx = steps.length;
+  if (region.endMatch) {
+    const endPrefixes = toArray(region.endMatch);
+    for (let i = startIdx + 1; i < steps.length; i++) {
+      if (matchesAny(steps[i].circuitName, endPrefixes)) {
+        endIdx = i;
+        break;
+      }
+    }
+  }
+
+  let sliced = steps.slice(startIdx, endIdx);
+
+  if (region.excludeKernels) {
+    sliced = sliced.filter(s => !isKernelCircuit(s.circuitName));
+  }
+
+  return sliced;
+}
+
+/** Extracts only kernel circuits from the full trace. */
+export function extractKernelOverhead(steps: GateCount[]): GateCount[] {
+  return steps.filter(s => isKernelCircuit(s.circuitName));
+}
+
+/** Extracts only non-kernel (application) circuits from the full trace. */
+export function extractAppLogic(steps: GateCount[]): GateCount[] {
+  return steps.filter(s => !isKernelCircuit(s.circuitName));
+}
+
+/**
+ * Returns a built-in region preset that splits the trace into "app" (non-kernel)
+ * and "kernel" (kernel overhead) regions. No configuration needed.
+ */
+export function kernelIsolation(): TraceRegion[] {
+  return [
+    { name: 'app', startMatch: '__all__', excludeKernels: true },
+    { name: 'kernel', startMatch: '__all__', excludeKernels: false },
+  ];
+}
+
+function sumGateCounts(steps: GateCount[]): number {
+  return steps.reduce((sum, s) => sum + (s.gateCount ?? 0), 0);
+}
+
+/**
+ * Applies an array of region definitions to a list of gate counts,
+ * returning a map of region name → RegionResult.
+ */
+export function applyRegions(
+  gateCounts: GateCount[],
+  regions: TraceRegion[],
+): Record<string, RegionResult> {
+  const result: Record<string, RegionResult> = {};
+
+  for (const region of regions) {
+    let extracted: GateCount[];
+
+    if (region.startMatch === '__all__') {
+      // Synthetic region: filter the full trace
+      extracted = region.excludeKernels
+        ? extractAppLogic(gateCounts)
+        : extractKernelOverhead(gateCounts);
+    } else {
+      extracted = extractRegion(gateCounts, region);
+    }
+
+    result[region.name] = {
+      totalGateCount: sumGateCounts(extracted),
+      gateCounts: extracted,
+    };
+  }
+
+  return result;
+}

--- a/cli/types.ts
+++ b/cli/types.ts
@@ -3,8 +3,10 @@ import type { ContractFunctionInteractionCallIntent } from '@aztec/aztec.js/auth
 import type { FeePaymentMethod } from '@aztec/aztec.js/fee';
 import { EmbeddedWallet } from '@aztec/wallets/embedded';
 import type { SystemInfo } from './systemInfo.js';
+import type { TraceRegion, RegionResult } from './traceRegions.js';
 
 export type { SystemInfo } from './systemInfo.js';
+export type { TraceRegion, RegionResult } from './traceRegions.js';
 
 /** Simplified Gas type (contains actual gas values) */
 export type Gas = {
@@ -49,6 +51,8 @@ export interface ProfileResult {
   gas?: GasLimits;
   /** Proving time in milliseconds. */
   provingTime?: number;
+  /** Per-region gate count breakdowns (present when benchmark defines getRegions()). */
+  regions?: Record<string, RegionResult>;
 }
 
 /** Defines a contract interaction to be benchmarked, with a custom display name. */
@@ -71,6 +75,8 @@ export interface ProfileReport {
   gasSummary: Record<string, number>;
   /** Proving time summary (in ms) keyed by function name */
   provingTimeSummary: Record<string, number>;
+  /** Per-region total gate counts: region name → function name → total gates. */
+  regionSummaries?: Record<string, Record<string, number>>;
   /** System information where the benchmark was run */
   systemInfo: SystemInfo;
 }
@@ -83,4 +89,6 @@ export abstract class BenchmarkBase {
   abstract getMethods(context: BenchmarkContext): Array<ContractFunctionInteractionCallIntent | NamedBenchmarkedInteraction>;
   /** Optional teardown function run after benchmarks (no longer abstract) */
   teardown?(context: BenchmarkContext): Promise<void>;
+  /** Optional: define named trace regions for per-region gate count breakdown. */
+  getRegions?(): TraceRegion[];
 } 


### PR DESCRIPTION
### Context

Transaction traces include kernel circuits (private_kernel_init, private_kernel_inner, etc.) interleaved with application circuits. Trace regions let benchmark authors isolate the portion they care about and detect regressions that would otherwise be hidden.

### Changes

- Adds trace region extraction, allowing benchmarks to isolate specific portions of the execution trace (e.g., app logic vs kernel overhead) and report per-region gate counts.
- Benchmarks define regions via an optional `getRegions()` method on the benchmark class. Each region specifies `startMatch`/`endMatch` circuit name prefixes and an optional `excludeKernels` flag.
- Ships a built-in `kernelIsolation()` preset that auto-splits traces into "app" and "kernel" regions.
- PR comparison comments include a collapsible per-region gate count breakdown, enabling regression detection at the region level — not just whole-transaction level.

### Usage

Benchmarks define regions by implementing the optional `getRegions()` method. Each region specifies which portion of the trace to extract using circuit name prefixes as boundaries:

  ```ts
  export default class MyBenchmark extends Benchmark {
    getRegions() {
      return [
        {
          name: 'my-contract',        // region name in reports
          startMatch: 'MyContract:',  // first circuit matching this prefix
          endMatch: 'Noop:',          // stop before this prefix (exclusive)
          excludeKernels: true,       // omit private_kernel_* and hiding_kernel
        },
      ];
    }
    // ...
  }
```
When regions are defined, the JSON report includes per-region gate counts on each result (regions) and a top-level summary (regionSummaries). PR comparison comments show a collapsible region breakdown section.